### PR TITLE
BAM-161: revert to use manual tag for java 6

### DIFF
--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -2,7 +2,11 @@ name: Java SDK Build & Release JDK8
 
 on:
   workflow_dispatch:
-
+    inputs:
+      kp_tag:
+        description: 'Optional: Use a specific tag; otherwise, default to the tag from kp-protocols-clientsdk'
+        required: false
+        default: ''
 env:
   GITHUB_ACTOR: ${{ github.actor }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -15,19 +19,23 @@ jobs:
       version: ${{ steps.tag.outputs.version }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
-      - name: Fetch head tag from kp-protocols-clientsdk
+      - name: Determine version tag from kp-protocols-clientsdk
         id: tag
         run: |
-          git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
-          cd proto-repo
-          head_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
-          if [[ -z "${head_tag}" ]]; then
+          if [ -n "${{ github.event.inputs.kp_tag }}" ]; then
+             version_tag=${{ github.event.inputs.kp_tag }}
+          else
+            git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+            cd proto-repo
+            version_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+          fi
+          if [[ -z "${version_tag}" ]]; then
             echo "No tag found on the head commit of kp-protocols-clientsdk repo. Failing the action."
             exit 1
           else
-            echo "tag=${head_tag}" >> $GITHUB_OUTPUT
-            echo "version=${head_tag#v}" >> $GITHUB_OUTPUT
-            if [[ "${head_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
+            echo "tag=${version_tag}" >> $GITHUB_OUTPUT
+            echo "version=${version_tag#v}" >> $GITHUB_OUTPUT
+            if [[ "${version_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
           fi
 
   publish:


### PR DESCRIPTION
## **Associated JIRA tasks**

BAM-161

## **What the code does.**

Revert to mainly use manual tag input action as sdk code is manually created.



## **Does this code change break backwards compatibility?.**

No

## **Tests**

Successful run for an alpha release can be found at https://github.com/KodyPay/kody-clientsdk-java6/actions/runs/12831681313